### PR TITLE
Refactor cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,254 @@
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### CMake template
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
 docs/_build/
-*~
-.DS_Store
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,112 +1,69 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
 
-# project
-enable_language(Fortran)
-set(ProjectName tc++)
-project(${ProjectName} CXX Fortran)
+project(TCpp
+		VERSION 1.3
+		LANGUAGES CXX Fortran)
 
-# compile option
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED OFF) # C++11 is sufficient but C++17 will accelerate calculation
-set(CMAKE_MACOSX_RPATH 1)
-set(CMAKE_CXX_FLAGS "-O2")
-set(CMAKE_CXX_EXTENSIONS OFF)
+## Project options
+option(TCPP_WITH_MPI "Tcpp: Build with MPI support" ON)
+option(TCPP_WITH_Boost "Tcpp: Build with Boost support" ON)
+option(TCPP_WITH_Eigen3 "Tcpp: Build with Eigen3 support" ON)
+option(TCPP_WITH_FFTW3 "Tcpp: Build with FFTW3 support" OFF)
 
-# external libraries
-find_package(MPI REQUIRED)
-include_directories(${MPI_CXX_INCLUDE_DIRS} ${MPI_Fortran_INCLUDE_DIRS})
+## Set standard options
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE Release)
+endif ()
+# Check C++ standards
+if ("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+	set(CMAKE_CXX_STANDARD 17)
+else ()
+	# TODO: Mark compiler standard for deprecation and announce release
+	message(WARNING
+			"Compiler ${CMAKE_CXX_COMPILER} does not support C++17 standard.\n"
+			"We highly recommend upgrading the compiler to get better support and performance.")
+	set(CMAKE_CXX_STANDARD 11)
+endif ()
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(GNUInstallDirs)
 
-if (BOOST_INCLUDE AND BOOST_LIB)
-    include_directories(${BOOST_INCLUDE})
-    set(BOOST_LIBRARIES ${BOOST_LIB})
-else()
-    find_package(Boost)
-    if (Boost_FOUND)
-        include_directories(${Boost_INCLUDE_DIRS})
-    else()
-        message(FATAL_ERROR "Boost was not found.
-        Please specify the location of Boost include and library directories
-        via -DBOOST_INCLUDE and -DBOOST_LIB options.")
-    endif()
-endif()
+## External libraries
+if (TCPP_WITH_MPI)
+	find_package(MPI REQUIRED)
+else ()
+	# TODO: Allow for non-mpi builds
+	message(FATAL_ERROR "Currently Tcpp requires MPI")
+endif ()
 
-if (EIGEN3_INCLUDE)
-    include_directories(${EIGEN3_INCLUDE})
-else()
-    find_package(Eigen3)
-    if (Eigen3_FOUND)
-        include_directories(${EIGEN3_INCLUDE_DIR})
-    else()
-        message(FATAL_ERROR "Eigen3 was not found.
-        Please specify the location of EIGEN3 include directories
-        via -DEIGEN3_INCLUDE option.")
-    endif()
-endif()
+if (TCPP_WITH_Boost)
+	# TODO: What components?
+	find_package(Boost REQUIRED)
+else ()
+	# TODO: Allow for non-boost builds
+	message(FATAL_ERROR "Currently Tcpp requires Boost")
+endif ()
+if (TCPP_WITH_Eigen3)
+	find_package(Eigen3 REQUIRED)
+else ()
+	# TODO: Allow for non-boost builds
+	message(FATAL_ERROR "Currently Tcpp requires Eigen3")
+endif ()
+if (TCPP_WITH_FFTW3)
+	find_package(FFTW REQUIRED)
+	set(FFTW_Target "FFTW::Double")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Intel.*")
+	find_package(MKL REQUIRED)
+	set(FFTW_Target "MKL::MKL")
+else ()
+	# TODO: Allow for non-boost builds
+	message(FATAL_ERROR "Currently Tcpp requires FFTW3 or Intel MKL")
+endif ()
 
-if (FFTW_INCLUDE AND FFTW_LIB)
-    include_directories(${FFTW_INCLUDE})
-    set(FFTW_LIBRARIES ${FFTW_LIB})
-else()
-    find_package(FFTW)
-    if (FFTW_FOUND)
-        include_directories(${FFTW_INCLUDE_DIRS})
-    else()
-        message(FATAL_ERROR "FFTW was not found.
-        Please specify the location of FFTW include and library directories
-        via -DFFTW_INCLUDE and -DFFTW_LIB options.")
-    endif()
-endif()
-
-include_directories("src/include")
-
-add_executable(${ProjectName}
-  src/my_clock.cpp
-  src/error_messages.cpp
-  src/parallelization.cpp
-  src/method.cpp
-  src/plane_wave_basis.cpp
-  src/symmetry.cpp
-  src/crystal_structure.cpp
-  src/potentials_pseudopot.cpp
-  src/potentials_coulomb.cpp
-  src/kpoints.cpp
-  src/file_names.cpp
-  src/jastrow_initialize.cpp
-  src/jastrow_functions.cpp
-  src/io_tc_files_read_input_in.cpp
-  src/io_tc_files_read_eigen.cpp
-  src/io_tc_files_read_scfinfo.cpp
-  src/io_tc_files_dump_eigen.cpp 
-  src/io_tc_files_dump_scfinfo.cpp
-  src/io_tc_files_dump_bandplot.cpp
-  src/read_qe.cpp
-  src/read_qe_xml.cpp 
-  src/read_upf.cpp
-  src/bloch_states_initialize.cpp
-  src/bloch_states_scfloop_filling_density.cpp
-  src/bloch_states_scfloop_phik.cpp
-  src/bloch_states_scfloop_eigenvalues.cpp
-  src/total_energy.cpp
-  src/spin.cpp
-  src/calc_hamiltonian_all.cpp
-  src/calc_hamiltonian_kinetic.cpp
-  src/calc_hamiltonian_pseudo.cpp
-  src/calc_hamiltonian_hf2h.cpp
-  src/calc_hamiltonian_hf2x.cpp
-  src/calc_hamiltonian_tc2h.cpp
-  src/calc_hamiltonian_tc2x.cpp
-  src/calc_hamiltonian_tc3a1.cpp
-  src/calc_hamiltonian_tc3b1.cpp
-  src/calc_hamiltonian_tc3a2a4b2b5.cpp
-  src/calc_hamiltonian_tc3a3b3b4b6.cpp
-  src/diagonalization.cpp
-  src/diagonalization_davidson.cpp
-  src/diagonalization_utils.cpp
-  src/main.cpp
-  src/read_qe_wfc.f90
-)
-target_link_libraries(${ProjectName} ${Boost_LIBRARIES} ${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES})
-target_link_libraries(${ProjectName} ${FFTW_LIBRARIES}/libfftw3.a)
-
-install(TARGETS ${ProjectName}
-	DESTINATION bin)
+# Main binary target
+add_executable(TCpp_tc++)
+# Target is namespaced for common practice. Add appropriate namespaced alias, export name and fix the executable name
+add_executable(TCpp::tc++ ALIAS TCpp_tc++)
+set_target_properties(TCpp_tc++ PROPERTIES
+		EXPORT_NAME tc++
+		OUTPUT_NAME tc++)
+add_subdirectory(src)

--- a/cmake/FindFFTW.cmake
+++ b/cmake/FindFFTW.cmake
@@ -1,0 +1,421 @@
+# Upstream version: https://github.com/egpbos/findFFTW
+# Removed TODOs to not interfere with local development. Otherwise the following is a direct copy of
+# ac788529392825067c9118f9f099aaa1efb77589
+# Additional changes by: Cristian Le
+# ----------------------------------------------------------------------------------------------------------------------
+# - Find the FFTW library
+#
+# Original version of this file:
+#   Copyright (c) 2015, Wenzel Jakob
+#   https://github.com/wjakob/layerlab/blob/master/cmake/FindFFTW.cmake, commit 4d58bfdc28891b4f9373dfe46239dda5a0b561c6
+# Modifications:
+#   Copyright (c) 2017, Patrick Bos
+#
+# Usage:
+#   find_package(FFTW [REQUIRED] [QUIET] [COMPONENTS component1 ... componentX] )
+#
+# It sets the following variables:
+#   FFTW_FOUND                  ... true if fftw is found on the system
+#   FFTW_[component]_LIB_FOUND  ... true if the component is found on the system (see components below)
+#   FFTW_LIBRARIES              ... full paths to all found fftw libraries
+#   FFTW_[component]_LIB        ... full path to one of the components (see below)
+#   FFTW_INCLUDE_DIRS           ... fftw include directory paths
+#
+# The following variables will be checked by the function
+#   FFTW_USE_STATIC_LIBS        ... if true, only static libraries are found, otherwise both static and shared.
+#   FFTW_ROOT                   ... if set, the libraries are exclusively searched
+#                                   under this path
+#
+# This package supports the following components:
+#   FLOAT_LIB
+#   DOUBLE_LIB
+#   LONGDOUBLE_LIB
+#   FLOAT_THREADS_LIB
+#   DOUBLE_THREADS_LIB
+#   LONGDOUBLE_THREADS_LIB
+#   FLOAT_OPENMP_LIB
+#   DOUBLE_OPENMP_LIB
+#   LONGDOUBLE_OPENMP_LIB
+#
+
+
+if( NOT FFTW_ROOT AND DEFINED ENV{FFTWDIR} )
+	set( FFTW_ROOT $ENV{FFTWDIR} )
+endif()
+
+# Check if we can use PkgConfig
+find_package(PkgConfig)
+
+#Determine from PKG
+if( PKG_CONFIG_FOUND AND NOT FFTW_ROOT )
+	pkg_check_modules( PKG_FFTW QUIET "fftw3" )
+endif()
+
+#Check whether to search static or dynamic libs
+set( CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+
+if( ${FFTW_USE_STATIC_LIBS} )
+	set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX} )
+else()
+	set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
+endif()
+
+if( FFTW_ROOT )
+	# find libs
+
+	find_library(
+			FFTW_DOUBLE_LIB
+			NAMES "fftw3" libfftw3-3
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_DOUBLE_THREADS_LIB
+			NAMES "fftw3_threads"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_DOUBLE_OPENMP_LIB
+			NAMES "fftw3_omp"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_DOUBLE_MPI_LIB
+			NAMES "fftw3_mpi"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_FLOAT_LIB
+			NAMES "fftw3f" libfftw3f-3
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_FLOAT_THREADS_LIB
+			NAMES "fftw3f_threads"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_FLOAT_OPENMP_LIB
+			NAMES "fftw3f_omp"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_FLOAT_MPI_LIB
+			NAMES "fftw3f_mpi"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_LONGDOUBLE_LIB
+			NAMES "fftw3l" libfftw3l-3
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_LONGDOUBLE_THREADS_LIB
+			NAMES "fftw3l_threads"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_LONGDOUBLE_OPENMP_LIB
+			NAMES "fftw3l_omp"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	find_library(
+			FFTW_LONGDOUBLE_MPI_LIB
+			NAMES "fftw3l_mpi"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "lib" "lib64"
+			NO_DEFAULT_PATH
+	)
+
+	#find includes
+	find_path(FFTW_INCLUDE_DIRS
+			NAMES "fftw3.h"
+			PATHS ${FFTW_ROOT}
+			PATH_SUFFIXES "include"
+			NO_DEFAULT_PATH
+			)
+
+else()
+
+	find_library(
+			FFTW_DOUBLE_LIB
+			NAMES "fftw3"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(
+			FFTW_DOUBLE_THREADS_LIB
+			NAMES "fftw3_threads"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(
+			FFTW_DOUBLE_OPENMP_LIB
+			NAMES "fftw3_omp"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(
+			FFTW_DOUBLE_MPI_LIB
+			NAMES "fftw3_mpi"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(
+			FFTW_FLOAT_LIB
+			NAMES "fftw3f"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(
+			FFTW_FLOAT_THREADS_LIB
+			NAMES "fftw3f_threads"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(
+			FFTW_FLOAT_OPENMP_LIB
+			NAMES "fftw3f_omp"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(
+			FFTW_FLOAT_MPI_LIB
+			NAMES "fftw3f_mpi"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(
+			FFTW_LONGDOUBLE_LIB
+			NAMES "fftw3l"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(
+			FFTW_LONGDOUBLE_THREADS_LIB
+			NAMES "fftw3l_threads"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+	)
+
+	find_library(FFTW_LONGDOUBLE_OPENMP_LIB
+			NAMES "fftw3l_omp"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+			)
+
+	find_library(FFTW_LONGDOUBLE_MPI_LIB
+			NAMES "fftw3l_mpi"
+			PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+			)
+
+	find_path(FFTW_INCLUDE_DIRS
+			NAMES "fftw3.h"
+			PATHS ${PKG_FFTW_INCLUDE_DIRS} ${INCLUDE_INSTALL_DIR}
+			)
+
+endif( FFTW_ROOT )
+
+#--------------------------------------- components
+
+if (FFTW_DOUBLE_LIB)
+	set(FFTW_DOUBLE_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_LIB})
+	add_library(FFTW::Double INTERFACE IMPORTED)
+	set_target_properties(FFTW::Double
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_LIB}"
+			)
+else()
+	set(FFTW_DOUBLE_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_FLOAT_LIB)
+	set(FFTW_FLOAT_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_LIB})
+	add_library(FFTW::Float INTERFACE IMPORTED)
+	set_target_properties(FFTW::Float
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_LIB}"
+			)
+else()
+	set(FFTW_FLOAT_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_LONGDOUBLE_LIB)
+	set(FFTW_LONGDOUBLE_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_LIB})
+	add_library(FFTW::LongDouble INTERFACE IMPORTED)
+	set_target_properties(FFTW::LongDouble
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_LIB}"
+			)
+else()
+	set(FFTW_LONGDOUBLE_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_DOUBLE_THREADS_LIB)
+	set(FFTW_DOUBLE_THREADS_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_THREADS_LIB})
+	add_library(FFTW::DoubleThreads INTERFACE IMPORTED)
+	set_target_properties(FFTW::DoubleThreads
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_THREADS_LIB}"
+			)
+else()
+	set(FFTW_DOUBLE_THREADS_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_FLOAT_THREADS_LIB)
+	set(FFTW_FLOAT_THREADS_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_THREADS_LIB})
+	add_library(FFTW::FloatThreads INTERFACE IMPORTED)
+	set_target_properties(FFTW::FloatThreads
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_THREADS_LIB}"
+			)
+else()
+	set(FFTW_FLOAT_THREADS_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_LONGDOUBLE_THREADS_LIB)
+	set(FFTW_LONGDOUBLE_THREADS_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_THREADS_LIB})
+	add_library(FFTW::LongDoubleThreads INTERFACE IMPORTED)
+	set_target_properties(FFTW::LongDoubleThreads
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_THREADS_LIB}"
+			)
+else()
+	set(FFTW_LONGDOUBLE_THREADS_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_DOUBLE_OPENMP_LIB)
+	set(FFTW_DOUBLE_OPENMP_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_OPENMP_LIB})
+	add_library(FFTW::DoubleOpenMP INTERFACE IMPORTED)
+	set_target_properties(FFTW::DoubleOpenMP
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_OPENMP_LIB}"
+			)
+else()
+	set(FFTW_DOUBLE_OPENMP_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_FLOAT_OPENMP_LIB)
+	set(FFTW_FLOAT_OPENMP_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_OPENMP_LIB})
+	add_library(FFTW::FloatOpenMP INTERFACE IMPORTED)
+	set_target_properties(FFTW::FloatOpenMP
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_OPENMP_LIB}"
+			)
+else()
+	set(FFTW_FLOAT_OPENMP_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_LONGDOUBLE_OPENMP_LIB)
+	set(FFTW_LONGDOUBLE_OPENMP_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_OPENMP_LIB})
+	add_library(FFTW::LongDoubleOpenMP INTERFACE IMPORTED)
+	set_target_properties(FFTW::LongDoubleOpenMP
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_OPENMP_LIB}"
+			)
+else()
+	set(FFTW_LONGDOUBLE_OPENMP_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_DOUBLE_MPI_LIB)
+	set(FFTW_DOUBLE_MPI_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_DOUBLE_MPI_LIB})
+	add_library(FFTW::DoubleMPI INTERFACE IMPORTED)
+	set_target_properties(FFTW::DoubleMPI
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_DOUBLE_MPI_LIB}"
+			)
+else()
+	set(FFTW_DOUBLE_MPI_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_FLOAT_MPI_LIB)
+	set(FFTW_FLOAT_MPI_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_FLOAT_MPI_LIB})
+	add_library(FFTW::FloatMPI INTERFACE IMPORTED)
+	set_target_properties(FFTW::FloatMPI
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_FLOAT_MPI_LIB}"
+			)
+else()
+	set(FFTW_FLOAT_MPI_LIB_FOUND FALSE)
+endif()
+
+if (FFTW_LONGDOUBLE_MPI_LIB)
+	set(FFTW_LONGDOUBLE_MPI_LIB_FOUND TRUE)
+	set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTW_LONGDOUBLE_MPI_LIB})
+	add_library(FFTW::LongDoubleMPI INTERFACE IMPORTED)
+	set_target_properties(FFTW::LongDoubleMPI
+			PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIRS}"
+			INTERFACE_LINK_LIBRARIES "${FFTW_LONGDOUBLE_MPI_LIB}"
+			)
+else()
+	set(FFTW_LONGDOUBLE_MPI_LIB_FOUND FALSE)
+endif()
+
+#--------------------------------------- end components
+
+set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(FFTW
+		REQUIRED_VARS FFTW_INCLUDE_DIRS
+		HANDLE_COMPONENTS
+		)
+
+mark_as_advanced(
+		FFTW_INCLUDE_DIRS
+		FFTW_LIBRARIES
+		FFTW_FLOAT_LIB
+		FFTW_DOUBLE_LIB
+		FFTW_LONGDOUBLE_LIB
+		FFTW_FLOAT_THREADS_LIB
+		FFTW_DOUBLE_THREADS_LIB
+		FFTW_LONGDOUBLE_THREADS_LIB
+		FFTW_FLOAT_OPENMP_LIB
+		FFTW_DOUBLE_OPENMP_LIB
+		FFTW_LONGDOUBLE_OPENMP_LIB
+		FFTW_FLOAT_MPI_LIB
+		FFTW_DOUBLE_MPI_LIB
+		FFTW_LONGDOUBLE_MPI_LIB
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,65 @@
+## Configure main executable
+target_sources(TCpp_tc++ PRIVATE
+		my_clock.cpp
+		error_messages.cpp
+		parallelization.cpp
+		method.cpp
+		plane_wave_basis.cpp
+		symmetry.cpp
+		crystal_structure.cpp
+		potentials_pseudopot.cpp
+		potentials_coulomb.cpp
+		kpoints.cpp
+		file_names.cpp
+		jastrow_initialize.cpp
+		jastrow_functions.cpp
+		io_tc_files_read_input_in.cpp
+		io_tc_files_read_eigen.cpp
+		io_tc_files_read_scfinfo.cpp
+		io_tc_files_dump_eigen.cpp
+		io_tc_files_dump_scfinfo.cpp
+		io_tc_files_dump_bandplot.cpp
+		read_qe.cpp
+		read_qe_xml.cpp
+		read_upf.cpp
+		bloch_states_initialize.cpp
+		bloch_states_scfloop_filling_density.cpp
+		bloch_states_scfloop_phik.cpp
+		bloch_states_scfloop_eigenvalues.cpp
+		total_energy.cpp
+		spin.cpp
+		calc_hamiltonian_all.cpp
+		calc_hamiltonian_kinetic.cpp
+		calc_hamiltonian_pseudo.cpp
+		calc_hamiltonian_hf2h.cpp
+		calc_hamiltonian_hf2x.cpp
+		calc_hamiltonian_tc2h.cpp
+		calc_hamiltonian_tc2x.cpp
+		calc_hamiltonian_tc3a1.cpp
+		calc_hamiltonian_tc3b1.cpp
+		calc_hamiltonian_tc3a2a4b2b5.cpp
+		calc_hamiltonian_tc3a3b3b4b6.cpp
+		diagonalization.cpp
+		diagonalization_davidson.cpp
+		diagonalization_utils.cpp
+		main.cpp
+		read_qe_wfc.f90
+		)
+target_include_directories(TCpp_tc++ PRIVATE include)
+
+## Link external libraries
+target_link_libraries(TCpp_tc++ PRIVATE ${FFTW_Target})
+if (TCPP_WITH_Boost)
+	# TODO: Only include relevant boost component
+	target_link_libraries(TCpp_tc++ PRIVATE Boost::boost)
+endif ()
+if (TCPP_WITH_MPI)
+	target_link_libraries(TCpp_tc++ PRIVATE MPI::MPI_CXX)
+endif ()
+if (TCPP_WITH_Eigen3)
+	target_link_libraries(TCpp_tc++ PRIVATE Eigen3::Eigen)
+endif ()
+
+## Install
+install(TARGETS TCpp_tc++
+		DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Hello Ochi-san, do you need some help with maintaining/developing this code?

I am maintaining a few projects so I can share some common standards that people use in cmake, c++ and so on. For example in this PR:
- Options should be namespaced. This is primarily relevant for libraries, but it is best to adapt this standard early on
- It is good practice to avoid punctuation in project name
  - On this note, is there a more suitable name to use for the project. I'm afraid there could be name-clashes for packaging in the future
-  Version in `project()`. Should also add other metadata like `DESCRIPTION` and `HOMEPAGE_URL`
- Build configuration should be options
  - It is possible to use `FetchContent` to automatically download missing dependencies
  - Some options should be allowed to be optional primarily `MPI` and `Boost`
- Targets should be linked by `find_package` targets, e.g. `mpi::mpi`

PS: There are a few more PRs that can come soon (check my fork branches)